### PR TITLE
Release of ReCiter CDK 2.0.0

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -2,16 +2,9 @@
   "app": "mvn -e -q compile exec:java",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
+    "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <cdk.version>2.15.0</cdk.version>
+        <constructs.version>[10.0.0,11.0.0)</constructs.version>
         <junit.version>5.7.1</junit.version>
     </properties>
 
@@ -70,7 +71,7 @@
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>10.0.12</version>
+            <version>${constructs.version}</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>edu.wcm.reciter</groupId>
     <artifactId>reciter-cdk</artifactId>
-    <version>1.2.0</version>
+    <version>2.0.0</version>
     <url>https://github.com/wcmc-its/ReCiter-CDK</url>
 
     <organization>
@@ -32,7 +32,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>1.122.0</cdk.version>
+        <cdk.version>2.8.0</cdk.version>
         <junit.version>5.7.1</junit.version>
     </properties>
 
@@ -61,75 +61,16 @@
 
     <dependencies>
         <!-- AWS Cloud Development Kit -->
+        <!-- https://mvnrepository.com/artifact/software.amazon.awscdk/aws-cdk-lib -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>aws-cdk-lib</artifactId>
             <version>${cdk.version}</version>
         </dependency>
         <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>ecr</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>rds</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>ec2</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>ecs</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>ecs-patterns</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>cloudwatch</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>cloudwatch-actions</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>wafv2</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>sns</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>secretsmanager</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>codebuild</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>codepipeline</artifactId>
-            <version>${cdk.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awscdk</groupId>
-            <artifactId>codepipeline-actions</artifactId>
-            <version>${cdk.version}</version>
+            <groupId>software.constructs</groupId>
+            <artifactId>constructs</artifactId>
+            <version>10.0.12</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.8.0</cdk.version>
+        <cdk.version>2.15.0</cdk.version>
         <junit.version>5.7.1</junit.version>
     </properties>
 

--- a/src/main/java/edu/wcm/reciter/ReCiterCDKECRStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCDKECRStack.java
@@ -2,12 +2,12 @@ package edu.wcm.reciter;
 
 import java.util.Arrays;
 
-import software.amazon.awscdk.core.CfnOutput;
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.NestedStack;
-import software.amazon.awscdk.core.NestedStackProps;
-import software.amazon.awscdk.core.RemovalPolicy;
-import software.amazon.awscdk.core.Tags;
+import software.amazon.awscdk.CfnOutput;
+import software.constructs.Construct;
+import software.amazon.awscdk.NestedStack;
+import software.amazon.awscdk.NestedStackProps;
+import software.amazon.awscdk.RemovalPolicy;
+import software.amazon.awscdk.Tags;
 import software.amazon.awscdk.services.ecr.Repository;
 import software.amazon.awscdk.services.ecr.RepositoryProps;
 import software.amazon.awscdk.services.ecr.LifecycleRule;

--- a/src/main/java/edu/wcm/reciter/ReCiterCDKECSStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCDKECSStack.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import software.amazon.awscdk.CfnJson;
 import software.amazon.awscdk.CfnJsonProps;
 import software.amazon.awscdk.CfnOutput;
-import software.constructs.Construct;
 import software.amazon.awscdk.Duration;
 import software.amazon.awscdk.NestedStack;
 import software.amazon.awscdk.NestedStackProps;
@@ -85,6 +84,7 @@ import software.amazon.awscdk.services.sns.SubscriptionProps;
 import software.amazon.awscdk.services.sns.SubscriptionProtocol;
 import software.amazon.awscdk.services.sns.Topic;
 import software.amazon.awscdk.services.sns.TopicProps;
+import software.constructs.Construct;
 
 public class ReCiterCDKECSStack extends NestedStack {
 
@@ -163,7 +163,7 @@ public class ReCiterCDKECSStack extends NestedStack {
         reCiterEcrRepo.grantPull(reCiterTaskDefinition.obtainExecutionRole());
 
         ContainerDefinition reCiterNginxContainer = reCiterTaskDefinition.addContainer("reCiterNginxContainer", ContainerDefinitionProps.builder()
-            .image(ContainerImage.fromRegistry("wcmcits/reciter-nginx:latest"))
+            .image(ContainerImage.fromRegistry("public.ecr.aws/wcmc-its/reciter-nginx:latest"))
             .logging(new AwsLogDriver(AwsLogDriverProps.builder()
                 .logGroup(new LogGroup(this, "reciterNginxLogGroup", LogGroupProps.builder()
                     .logGroupName("/ecs/reciter/nginx")
@@ -188,7 +188,7 @@ public class ReCiterCDKECSStack extends NestedStack {
 
         
         ContainerDefinition reCiterContainer = reCiterTaskDefinition.addContainer("reCiterContainer", ContainerDefinitionProps.builder()
-            .image(ContainerImage.fromRegistry("wcmcits/reciter:latest"))
+            .image(ContainerImage.fromRegistry("public.ecr.aws/wcmc-its/reciter:latest"))
             .logging(new AwsLogDriver(AwsLogDriverProps.builder()
                 .logGroup(new LogGroup(this, "reciterLogGroup", LogGroupProps.builder()
                     .logGroupName("/ecs/reciter")
@@ -272,7 +272,7 @@ public class ReCiterCDKECSStack extends NestedStack {
         reCiterPubmedEcrRep.grantPull(reCiterPubmedTaskDefinition.obtainExecutionRole());
 
         ContainerDefinition reCiterPubmedNginxContainer = reCiterPubmedTaskDefinition.addContainer("reCiterPubmedNginxContainer", ContainerDefinitionProps.builder()
-            .image(ContainerImage.fromRegistry("wcmcits/reciter-pubmed-nginx:latest"))
+            .image(ContainerImage.fromRegistry("public.ecr.aws/wcmc-its/reciter-pubmed-retrieval-tool-nginx:latest"))
             .logging(new AwsLogDriver(AwsLogDriverProps.builder()
                     .logGroup(new LogGroup(this, "reciterNginxPubmedLogGroup", LogGroupProps.builder()
                         .logGroupName("/ecs/reciter/pubmed/nginx")
@@ -297,7 +297,7 @@ public class ReCiterCDKECSStack extends NestedStack {
 
         
         ContainerDefinition reCiterPubmedContainer = reCiterPubmedTaskDefinition.addContainer("reCiterPubmedContainer", ContainerDefinitionProps.builder()
-            .image(ContainerImage.fromRegistry("wcmcits/reciter-pubmed:latest"))
+            .image(ContainerImage.fromRegistry("public.ecr.aws/wcmc-its/reciter-pubmed-retrieval-tool:latest"))
             .logging(new AwsLogDriver(AwsLogDriverProps.builder()
                 .logGroup(new LogGroup(this, "reciterPubmedLogGroup", LogGroupProps.builder()
                     .logGroupName("/ecs/reciter/pubmed")
@@ -361,7 +361,7 @@ public class ReCiterCDKECSStack extends NestedStack {
             reCiterScopusEcrRepo.grantPull(reCiterScopusTaskDefinition.obtainExecutionRole());
             
             ContainerDefinition reCiterScopusNginxContainer = reCiterScopusTaskDefinition.addContainer("reCiterScopusNginxContainer", ContainerDefinitionProps.builder()
-                .image(ContainerImage.fromRegistry("wcmcits/reciter-scopus-nginx:latest"))
+                .image(ContainerImage.fromRegistry("public.ecr.aws/wcmc-its/reciter-scopus-retrieval-tool-nginx:latest"))
                 .logging(new AwsLogDriver(AwsLogDriverProps.builder()
                     .logGroup(new LogGroup(this, "reciterNginxScopusLogGroup", LogGroupProps.builder()
                         .logGroupName("/ecs/reciter/scopus/nginx")
@@ -385,7 +385,7 @@ public class ReCiterCDKECSStack extends NestedStack {
                 .build());
             
             ContainerDefinition reCiterScopusContainer = reCiterScopusTaskDefinition.addContainer("reCiterScopusContainer", ContainerDefinitionProps.builder()
-                .image(ContainerImage.fromRegistry("wcmcits/reciter-scopus:latest"))
+                .image(ContainerImage.fromRegistry("public.ecr.aws/wcmc-its/reciter-scopus-retrieval-tool:latest"))
                 .logging(new AwsLogDriver(AwsLogDriverProps.builder()
                     .logGroup(new LogGroup(this, "reciterScopusLogGroup", LogGroupProps.builder()
                         .logGroupName("/ecs/reciter/scopus")
@@ -454,7 +454,7 @@ public class ReCiterCDKECSStack extends NestedStack {
 
         
         ContainerDefinition reCiterPubManagerContainer = reCiterPubManagerTaskDefinition.addContainer("reCiterScopusContainer", ContainerDefinitionProps.builder()
-            .image(ContainerImage.fromRegistry("wcmcits/reciter-publication-manager:latest"))
+            .image(ContainerImage.fromRegistry("public.ecr.aws/wcmc-its/reciter-publication-manager:latest"))
             .logging(new AwsLogDriver(AwsLogDriverProps.builder()
                 .logGroup(new LogGroup(this, "reciterPubManagerLogGroup", LogGroupProps.builder()
                     .logGroupName("/ecs/reciter/pub/manager")
@@ -870,7 +870,7 @@ public class ReCiterCDKECSStack extends NestedStack {
         reCiterMachineLearningFargateTask.getTaskDefinition().addContainer("reciter-machine-learning-analysis", ContainerDefinitionOptions.builder()
             .cpu(1024)
             .memoryLimitMiB(8000)
-            .image(ContainerImage.fromRegistry("wcmcits/reciter-machine-learning-analysis:latest"))
+            .image(ContainerImage.fromRegistry("public.ecr.aws/wcmc-its/reciter-machine-learning-analysis:latest"))
             .containerName("reciter-machine-learning-analysis")
             .healthCheck(HealthCheck.builder()
                     .command(Arrays.asList("CMD-SHELL", "cat /usr/src/app/Dynamodb_Analysis_upload.py || exit 1"))

--- a/src/main/java/edu/wcm/reciter/ReCiterCDKECSStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCDKECSStack.java
@@ -4,15 +4,15 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 
-import software.amazon.awscdk.core.CfnJson;
-import software.amazon.awscdk.core.CfnJsonProps;
-import software.amazon.awscdk.core.CfnOutput;
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.Duration;
-import software.amazon.awscdk.core.NestedStack;
-import software.amazon.awscdk.core.NestedStackProps;
-import software.amazon.awscdk.core.RemovalPolicy;
-import software.amazon.awscdk.core.Tags;
+import software.amazon.awscdk.CfnJson;
+import software.amazon.awscdk.CfnJsonProps;
+import software.amazon.awscdk.CfnOutput;
+import software.constructs.Construct;
+import software.amazon.awscdk.Duration;
+import software.amazon.awscdk.NestedStack;
+import software.amazon.awscdk.NestedStackProps;
+import software.amazon.awscdk.RemovalPolicy;
+import software.amazon.awscdk.Tags;
 import software.amazon.awscdk.services.applicationautoscaling.CronOptions;
 import software.amazon.awscdk.services.applicationautoscaling.EnableScalingProps;
 import software.amazon.awscdk.services.applicationautoscaling.Schedule;
@@ -257,7 +257,7 @@ public class ReCiterCDKECSStack extends NestedStack {
             .propagateTags(PropagatedTagSource.SERVICE)
             .vpcSubnets(SubnetSelection.builder()
                 .onePerAz(true)
-                .subnetType(SubnetType.PRIVATE)
+                .subnetType(SubnetType.PRIVATE_WITH_NAT)
                 .build())
             .securityGroups(Arrays.asList(reciterClusterSg))
             .build());
@@ -345,7 +345,7 @@ public class ReCiterCDKECSStack extends NestedStack {
             .propagateTags(PropagatedTagSource.SERVICE)
             .vpcSubnets(SubnetSelection.builder()
                 .onePerAz(true)
-                .subnetType(SubnetType.PRIVATE)
+                .subnetType(SubnetType.PRIVATE_WITH_NAT)
                 .build())
             .securityGroups(Arrays.asList(reciterClusterSg))
             .build());
@@ -437,7 +437,7 @@ public class ReCiterCDKECSStack extends NestedStack {
                 .propagateTags(PropagatedTagSource.SERVICE)
                 .vpcSubnets(SubnetSelection.builder()
                     .onePerAz(true)
-                    .subnetType(SubnetType.PRIVATE)
+                    .subnetType(SubnetType.PRIVATE_WITH_NAT)
                     .build())
                 .securityGroups(Arrays.asList(reciterClusterSg))
                 .build());
@@ -495,7 +495,7 @@ public class ReCiterCDKECSStack extends NestedStack {
             .propagateTags(PropagatedTagSource.SERVICE)
             .vpcSubnets(SubnetSelection.builder()
                 .onePerAz(true)
-                .subnetType(SubnetType.PRIVATE)
+                .subnetType(SubnetType.PRIVATE_WITH_NAT)
                 .build())
             .securityGroups(Arrays.asList(albSg))
             .build());
@@ -799,7 +799,7 @@ public class ReCiterCDKECSStack extends NestedStack {
             .vpc(vpc)
             .subnetSelection(SubnetSelection.builder()
                 .onePerAz(true)
-                .subnetType(SubnetType.PRIVATE)
+                .subnetType(SubnetType.PRIVATE_WITH_NAT)
                 .build())
             .securityGroups(Arrays.asList(reciterClusterSg))
             .scheduledFargateTaskDefinitionOptions(ScheduledFargateTaskDefinitionOptions.builder()

--- a/src/main/java/edu/wcm/reciter/ReCiterCDKVPCStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCDKVPCStack.java
@@ -4,14 +4,14 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 
-import software.amazon.awscdk.core.Aspects;
-import software.amazon.awscdk.core.CfnOutput;
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.NestedStack;
-import software.amazon.awscdk.core.NestedStackProps;
-import software.amazon.awscdk.core.RemovalPolicy;
-import software.amazon.awscdk.core.Tag;
-import software.amazon.awscdk.core.Tags;
+import software.amazon.awscdk.Aspects;
+import software.amazon.awscdk.CfnOutput;
+import software.constructs.Construct;
+import software.amazon.awscdk.NestedStack;
+import software.amazon.awscdk.NestedStackProps;
+import software.amazon.awscdk.RemovalPolicy;
+import software.amazon.awscdk.Tag;
+import software.amazon.awscdk.Tags;
 import software.amazon.awscdk.services.ec2.FlowLogDestination;
 import software.amazon.awscdk.services.ec2.FlowLogOptions;
 import software.amazon.awscdk.services.ec2.FlowLogTrafficType;
@@ -48,8 +48,8 @@ public class ReCiterCDKVPCStack extends NestedStack {
             .natGateways(2)
             .maxAzs(2)
             .subnetConfiguration(Arrays.asList(SubnetConfiguration.builder().cidrMask(24).name("reciter-public-subnet").subnetType(SubnetType.PUBLIC).build(),
-                SubnetConfiguration.builder().cidrMask(24).name("reciter-private-app-subnet").subnetType(SubnetType.PRIVATE).build(),
-                SubnetConfiguration.builder().cidrMask(28).name("reciter-private-db-subnet").subnetType(SubnetType.PRIVATE).build()))
+                SubnetConfiguration.builder().cidrMask(24).name("reciter-private-app-subnet").subnetType(SubnetType.PRIVATE_WITH_NAT).build(),
+                SubnetConfiguration.builder().cidrMask(28).name("reciter-private-db-subnet").subnetType(SubnetType.PRIVATE_WITH_NAT).build()))
             .enableDnsHostnames(true)
             .flowLogs(new HashMap<String, FlowLogOptions>(){{
                 put("reciter-flow-logs", FlowLogOptions.builder()
@@ -71,7 +71,7 @@ public class ReCiterCDKVPCStack extends NestedStack {
             .removalPolicy(RemovalPolicy.DESTROY)
             .subnetGroupName("reciter-private-subnet-group")
             .vpc(reciterVpc)
-            .vpcSubnets(SubnetSelection.builder().subnetType(SubnetType.PRIVATE).build())
+            .vpcSubnets(SubnetSelection.builder().subnetType(SubnetType.PRIVATE_WITH_NAT).build())
             .build());
         
         

--- a/src/main/java/edu/wcm/reciter/ReCiterCdkApp.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCdkApp.java
@@ -20,7 +20,7 @@ public class ReCiterCdkApp {
     }
     public static void main(final String[] args) {
         App app = new App();
-        Environment envReCiter = makeEnv(null, "us-east-2");
+        Environment envReCiter = makeEnv(null, null);
         if((System.getenv("ADMIN_API_KEY") == null || System.getenv("ADMIN_API_KEY").isEmpty())
         ||
         (System.getenv("CONSUMER_API_KEY") == null || System.getenv("CONSUMER_API_KEY").isEmpty())

--- a/src/main/java/edu/wcm/reciter/ReCiterCdkApp.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCdkApp.java
@@ -2,9 +2,9 @@ package edu.wcm.reciter;
 
 import java.util.HashMap;
 
-import software.amazon.awscdk.core.App;
-import software.amazon.awscdk.core.Environment;
-import software.amazon.awscdk.core.StackProps;
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.Environment;
+import software.amazon.awscdk.StackProps;
 
 public class ReCiterCdkApp {
 
@@ -20,7 +20,7 @@ public class ReCiterCdkApp {
     }
     public static void main(final String[] args) {
         App app = new App();
-        Environment envReCiter = makeEnv(null, null);
+        Environment envReCiter = makeEnv(null, "us-east-2");
         if((System.getenv("ADMIN_API_KEY") == null || System.getenv("ADMIN_API_KEY").isEmpty())
         ||
         (System.getenv("CONSUMER_API_KEY") == null || System.getenv("CONSUMER_API_KEY").isEmpty())

--- a/src/main/java/edu/wcm/reciter/ReCiterCdkPipelineStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCdkPipelineStack.java
@@ -6,10 +6,8 @@ import java.util.HashMap;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import software.constructs.Construct;
 import software.amazon.awscdk.NestedStack;
 import software.amazon.awscdk.NestedStackProps;
-import software.amazon.awscdk.RemovalPolicy;
 import software.amazon.awscdk.SecretValue;
 import software.amazon.awscdk.services.codebuild.BuildEnvironment;
 import software.amazon.awscdk.services.codebuild.BuildEnvironmentVariable;
@@ -47,6 +45,7 @@ import software.amazon.awscdk.services.iam.PolicyStatement;
 import software.amazon.awscdk.services.secretsmanager.ISecret;
 import software.amazon.awscdk.services.secretsmanager.Secret;
 import software.amazon.awscdk.services.sns.Topic;
+import software.constructs.Construct;
 
 public class ReCiterCdkPipelineStack extends NestedStack {
 

--- a/src/main/java/edu/wcm/reciter/ReCiterCdkPipelineStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCdkPipelineStack.java
@@ -6,10 +6,11 @@ import java.util.HashMap;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.NestedStack;
-import software.amazon.awscdk.core.NestedStackProps;
-import software.amazon.awscdk.core.SecretValue;
+import software.constructs.Construct;
+import software.amazon.awscdk.NestedStack;
+import software.amazon.awscdk.NestedStackProps;
+import software.amazon.awscdk.RemovalPolicy;
+import software.amazon.awscdk.SecretValue;
 import software.amazon.awscdk.services.codebuild.BuildEnvironment;
 import software.amazon.awscdk.services.codebuild.BuildEnvironmentVariable;
 import software.amazon.awscdk.services.codebuild.BuildEnvironmentVariableType;
@@ -89,7 +90,7 @@ public class ReCiterCdkPipelineStack extends NestedStack {
             .vpc(vpc)
             .subnetSelection(SubnetSelection.builder()
                 .onePerAz(true)
-                .subnetType(SubnetType.PRIVATE)
+                .subnetType(SubnetType.PRIVATE_WITH_NAT)
                 .build())
             .environment(BuildEnvironment.builder()
                 .buildImage(LinuxBuildImage.AMAZON_LINUX_2_3)
@@ -162,7 +163,7 @@ public class ReCiterCdkPipelineStack extends NestedStack {
                 .vpc(vpc)
                 .subnetSelection(SubnetSelection.builder()
                     .onePerAz(true)
-                    .subnetType(SubnetType.PRIVATE)
+                    .subnetType(SubnetType.PRIVATE_WITH_NAT)
                     .build())
                 .environmentVariables(new HashMap<String, BuildEnvironmentVariable>(){{
                     put("ECR_REPO_URI", BuildEnvironmentVariable.builder()
@@ -225,7 +226,7 @@ public class ReCiterCdkPipelineStack extends NestedStack {
             .vpc(vpc)
                 .subnetSelection(SubnetSelection.builder()
                     .onePerAz(true)
-                    .subnetType(SubnetType.PRIVATE)
+                    .subnetType(SubnetType.PRIVATE_WITH_NAT)
                     .build())
             .environment(BuildEnvironment.builder()
                 .buildImage(LinuxBuildImage.AMAZON_LINUX_2_3)
@@ -293,7 +294,7 @@ public class ReCiterCdkPipelineStack extends NestedStack {
             .vpc(vpc)
                 .subnetSelection(SubnetSelection.builder()
                     .onePerAz(true)
-                    .subnetType(SubnetType.PRIVATE)
+                    .subnetType(SubnetType.PRIVATE_WITH_NAT)
                     .build())
             .environment(BuildEnvironment.builder()
                 .buildImage(LinuxBuildImage.AMAZON_LINUX_2_3)
@@ -380,7 +381,7 @@ public class ReCiterCdkPipelineStack extends NestedStack {
             .vpc(vpc)
                 .subnetSelection(SubnetSelection.builder()
                     .onePerAz(true)
-                    .subnetType(SubnetType.PRIVATE)
+                    .subnetType(SubnetType.PRIVATE_WITH_NAT)
                     .build())
             .environment(BuildEnvironment.builder()
                 .buildImage(LinuxBuildImage.AMAZON_LINUX_2_3)

--- a/src/main/java/edu/wcm/reciter/ReCiterCdkRDSStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCdkRDSStack.java
@@ -1,9 +1,10 @@
 package edu.wcm.reciter;
 
+import java.util.HashMap;
+
 import org.json.JSONObject;
 
 import software.amazon.awscdk.CfnOutput;
-import software.constructs.Construct;
 import software.amazon.awscdk.Duration;
 import software.amazon.awscdk.NestedStack;
 import software.amazon.awscdk.NestedStackProps;
@@ -21,10 +22,12 @@ import software.amazon.awscdk.services.rds.DatabaseInstanceProps;
 import software.amazon.awscdk.services.rds.LicenseModel;
 import software.amazon.awscdk.services.rds.MariaDbEngineVersion;
 import software.amazon.awscdk.services.rds.MariaDbInstanceEngineProps;
+import software.amazon.awscdk.services.rds.ParameterGroup;
 import software.amazon.awscdk.services.rds.StorageType;
 import software.amazon.awscdk.services.rds.SubnetGroup;
 import software.amazon.awscdk.services.secretsmanager.Secret;
 import software.amazon.awscdk.services.secretsmanager.SecretStringGenerator;
+import software.constructs.Construct;
 
 public class ReCiterCdkRDSStack extends NestedStack {
 
@@ -58,6 +61,15 @@ public class ReCiterCdkRDSStack extends NestedStack {
             .port(3306)
             .removalPolicy(RemovalPolicy.DESTROY)
             .storageType(StorageType.GP2)
+            .parameterGroup(ParameterGroup.Builder.create(this, "reciterReportDbParameterGroup")
+                .engine(DatabaseInstanceEngine.mariaDb(MariaDbInstanceEngineProps.builder()
+                    .version(MariaDbEngineVersion.VER_10_5_13)
+                    .build()))
+                .description("This is the parameter group for reciter-report-db for MariaDB 10.5.13")
+                .parameters(new HashMap<String, String>(){{
+                    put("event_scheduler", "ON");
+                }})
+                .build())
             .subnetGroup(publicDbSubnetGroup)
             .preferredBackupWindow("01:00-02:00")
             .preferredMaintenanceWindow("Sat:03:00-Sat:05:00")

--- a/src/main/java/edu/wcm/reciter/ReCiterCdkRDSStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCdkRDSStack.java
@@ -2,13 +2,13 @@ package edu.wcm.reciter;
 
 import org.json.JSONObject;
 
-import software.amazon.awscdk.core.CfnOutput;
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.Duration;
-import software.amazon.awscdk.core.NestedStack;
-import software.amazon.awscdk.core.NestedStackProps;
-import software.amazon.awscdk.core.RemovalPolicy;
-import software.amazon.awscdk.core.Tags;
+import software.amazon.awscdk.CfnOutput;
+import software.constructs.Construct;
+import software.amazon.awscdk.Duration;
+import software.amazon.awscdk.NestedStack;
+import software.amazon.awscdk.NestedStackProps;
+import software.amazon.awscdk.RemovalPolicy;
+import software.amazon.awscdk.Tags;
 import software.amazon.awscdk.services.ec2.IVpc;
 import software.amazon.awscdk.services.ec2.InstanceClass;
 import software.amazon.awscdk.services.ec2.InstanceSize;
@@ -39,7 +39,7 @@ public class ReCiterCdkRDSStack extends NestedStack {
 
         reciterDb = new DatabaseInstance(this, "reciterDb", DatabaseInstanceProps.builder()
             .engine(DatabaseInstanceEngine.mariaDb(MariaDbInstanceEngineProps.builder()
-                .version(MariaDbEngineVersion.VER_10_5_9)
+                .version(MariaDbEngineVersion.VER_10_5_13)
                 .build()))
             .vpc(vpc)
             .allocatedStorage(50)

--- a/src/main/java/edu/wcm/reciter/ReCiterCdkSecretsManagerStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCdkSecretsManagerStack.java
@@ -2,10 +2,10 @@ package edu.wcm.reciter;
 
 import org.json.JSONObject;
 
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.NestedStack;
-import software.amazon.awscdk.core.NestedStackProps;
-import software.amazon.awscdk.core.RemovalPolicy;
+import software.constructs.Construct;
+import software.amazon.awscdk.NestedStack;
+import software.amazon.awscdk.NestedStackProps;
+import software.amazon.awscdk.RemovalPolicy;
 import software.amazon.awscdk.services.secretsmanager.ISecret;
 import software.amazon.awscdk.services.secretsmanager.Secret;
 import software.amazon.awscdk.services.secretsmanager.SecretProps;

--- a/src/main/java/edu/wcm/reciter/ReCiterCdkStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCdkStack.java
@@ -1,11 +1,11 @@
 package edu.wcm.reciter;
 
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.NestedStack;
-import software.amazon.awscdk.core.NestedStackProps;
-import software.amazon.awscdk.core.RemovalPolicy;
-import software.amazon.awscdk.core.Stack;
-import software.amazon.awscdk.core.StackProps;
+import software.constructs.Construct;
+import software.amazon.awscdk.NestedStack;
+import software.amazon.awscdk.NestedStackProps;
+import software.amazon.awscdk.RemovalPolicy;
+import software.amazon.awscdk.Stack;
+import software.amazon.awscdk.StackProps;
 
 public class ReCiterCdkStack extends Stack {
     public ReCiterCdkStack(final Construct scope, final String id) {

--- a/src/main/java/edu/wcm/reciter/ReCiterCdkWAFStack.java
+++ b/src/main/java/edu/wcm/reciter/ReCiterCdkWAFStack.java
@@ -3,11 +3,11 @@ package edu.wcm.reciter;
 import java.util.Arrays;
 import java.util.HashMap;
 
-import software.amazon.awscdk.core.CfnOutput;
-import software.amazon.awscdk.core.Construct;
-import software.amazon.awscdk.core.NestedStack;
-import software.amazon.awscdk.core.NestedStackProps;
-import software.amazon.awscdk.core.Tags;
+import software.amazon.awscdk.CfnOutput;
+import software.constructs.Construct;
+import software.amazon.awscdk.NestedStack;
+import software.amazon.awscdk.NestedStackProps;
+import software.amazon.awscdk.Tags;
 import software.amazon.awscdk.services.elasticloadbalancingv2.ApplicationLoadBalancer;
 import software.amazon.awscdk.services.wafv2.CfnWebACL;
 import software.amazon.awscdk.services.wafv2.CfnWebACL.AllowActionProperty;

--- a/src/test/java/edu/wcm/reciter/ReCiterCdkTest.java
+++ b/src/test/java/edu/wcm/reciter/ReCiterCdkTest.java
@@ -11,8 +11,8 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 
 import org.junit.jupiter.api.Test;
 
-import software.amazon.awscdk.core.App;
-import software.amazon.awscdk.core.StackProps;
+import software.amazon.awscdk.App;
+import software.amazon.awscdk.StackProps;
 
 public class ReCiterCdkTest {
     private final static ObjectMapper JSON =


### PR DESCRIPTION
- All ReCiter images are available publicly through Amazon ECR public gallery - [AWS ECR ReCiter Public gallery](https://gallery.ecr.aws/?searchTerm=reciter)
- [change all images to reciter public ecr repo](https://github.com/wcmc-its/ReCiter-CDK/pull/4/commits/baf2248d73a8dba07671868d17039058048a9f9b)
- upgrade to aws-cdk version 2 since thats the LTS version
- aws-cdk bumped to 2.15.0
- Update deprecated code
- Update mariadb database engine version - #1 #2 
- Add custom parameter group for database - https://github.com/wcmc-its/ReCiter-CDK/commit/26cc714d6ecebc84d8385df58b116cc0d801099b
